### PR TITLE
Fix product documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ The Gradient ADK is designed to work with any Python-based AI agent framework:
 
 - **Examples**: [https://github.com/digitalocean/gradient-adk-examples](https://github.com/digitalocean/gradient-adk-examples)
 - **Gradient Platform**: [https://www.digitalocean.com/products/gradient/platform](https://www.digitalocean.com/products/gradient/platform)
-- **Documentation**: [https://docs.digitalocean.com/products/gen-ai](https://docs.digitalocean.com/products/gen-ai)
+- **Documentation**: [https://docs.digitalocean.com/products/gradient-ai-platform/](https://docs.digitalocean.com/products/gradient-ai-platform/)
 - **API Reference**: [https://docs.digitalocean.com/reference/api](https://docs.digitalocean.com/reference/api)
 - **Community**: [DigitalOcean Community Forums](https://www.digitalocean.com/community)
 


### PR DESCRIPTION
`https://docs.digitalocean.com/products/gen-ai` leads to a 404. I think the correctly ink is probably `https://docs.digitalocean.com/products/gradient-ai-platform/` now.