### PR TITLE
Enable using gradient-adk on python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ dependencies = [
   "httpx>=0.26.0",
   "requests>=2.32.5",
   "pytest-mock>=3.15.1",
-  "langgraph==1.0.0",
-  "gradient>=3.6.0",
+  "langgraph>=1.0.0",
+  "gradient>=3.10.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Adds support for using ADK on Python 3.14 by ensuring that any version of LangGraph > 1.0.0 can be used (which is required as the 1.0.0 uses a non compatible version of pydantic.

Also ups the version of the Gradient SDK.