### PR TITLE
Add region support for ADK agent deployments

### DIFF
--- a/gradient_adk/cli/agent/deployment/deploy_service.py
+++ b/gradient_adk/cli/agent/deployment/deploy_service.py
@@ -44,6 +44,7 @@ class DeployService(Protocol):
         source_dir: Path,
         project_id: str,
         api_token: str,
+        region: str | None = None,
     ) -> None:
         """Deploy the agent to the configured environment."""
         ...
@@ -86,6 +87,7 @@ class AgentDeployService:
         project_id: str,
         api_token: str,
         description: str | None = None,
+        region: str | None = None,
     ) -> str:
         """Deploy an agent to the platform.
 
@@ -139,6 +141,7 @@ class AgentDeployService:
                 code_artifact=code_artifact,
                 project_id=project_id,
                 description=description,
+                region=region,
             )
 
             # Poll for deployment completion
@@ -319,6 +322,7 @@ class AgentDeployService:
         code_artifact: AgentDeploymentCodeArtifact,
         project_id: str,
         description: str | None = None,
+        region: str | None = None,
     ) -> str:
         """Create or update the deployment based on what exists.
 
@@ -344,6 +348,7 @@ class AgentDeployService:
                 project_id=project_id,
                 library_version=_get_adk_version(),
                 description=description,
+                region=region,
             )
             workspace_output = await self.client.create_agent_workspace(workspace_input)
 
@@ -371,6 +376,7 @@ class AgentDeployService:
                 agent_deployment_code_artifact=code_artifact,
                 library_version=_get_adk_version(),
                 description=description,
+                region=region,
             )
             deployment_output = await self.client.create_agent_workspace_deployment(
                 deployment_input

--- a/gradient_adk/cli/cli.py
+++ b/gradient_adk/cli/cli.py
@@ -469,8 +469,9 @@ def agent_deploy(
                     )
                     raise typer.Exit(1)
 
-                # Get description from config (optional)
+                # Get optional config values
                 description = _agent_config_manager.get_description()
+                region = _agent_config_manager.get_region()
 
                 # Load .gradientignore patterns and create deploy service
                 exclude_patterns = load_gradientignore(Path.cwd())
@@ -487,6 +488,7 @@ def agent_deploy(
                     project_id=project_id,
                     api_token=api_token,
                     description=description,
+                    region=region,
                 )
 
                 invoke_url = f"https://agents.do-ai.run/v1/{workspace_uuid}/{agent_deployment_name}/run"

--- a/gradient_adk/cli/config/agent_config_manager.py
+++ b/gradient_adk/cli/config/agent_config_manager.py
@@ -20,6 +20,9 @@ class AgentConfigManager:
     def get_description(self) -> Optional[str]:
         raise NotImplementedError
 
+    def get_region(self) -> Optional[str]:
+        raise NotImplementedError
+
     def configure(
         self,
         agent_name: Optional[str] = None,

--- a/gradient_adk/cli/config/yaml_agent_config_manager.py
+++ b/gradient_adk/cli/config/yaml_agent_config_manager.py
@@ -45,12 +45,17 @@ class YamlAgentConfigManager(AgentConfigManager):
         config = self.load_config()
         return config.get("description") if config else None
 
+    def get_region(self) -> Optional[str]:
+        config = self.load_config()
+        return config.get("region") if config else None
+
     def configure(
         self,
         agent_name: Optional[str] = None,
         agent_environment: Optional[str] = None,
         entrypoint_file: Optional[str] = None,
         description: Optional[str] = None,
+        region: Optional[str] = None,
         interactive: bool = True,
     ) -> None:
         """Configure agent settings and save to YAML file."""
@@ -107,7 +112,7 @@ class YamlAgentConfigManager(AgentConfigManager):
             raise typer.Exit(1)
 
         self._validate_entrypoint_file(entrypoint_file)
-        self._save_config(agent_name, agent_environment, entrypoint_file, description)
+        self._save_config(agent_name, agent_environment, entrypoint_file, description, region)
 
     def _validate_name(self, name: str) -> bool:
         """Validate that a name only contains alphanumeric characters, hyphens, and underscores."""
@@ -178,6 +183,7 @@ class YamlAgentConfigManager(AgentConfigManager):
         agent_environment: str,
         entrypoint_file: str,
         description: Optional[str] = None,
+        region: Optional[str] = None,
     ) -> None:
         """Save configuration to YAML file."""
         config = {
@@ -186,9 +192,11 @@ class YamlAgentConfigManager(AgentConfigManager):
             "entrypoint_file": entrypoint_file,
         }
 
-        # Only include description if provided
         if description is not None:
             config["description"] = description
+
+        if region is not None:
+            config["region"] = region
 
         try:
             with open(self.config_file, "w") as f:

--- a/gradient_adk/digital_ocean_api/models.py
+++ b/gradient_adk/digital_ocean_api/models.py
@@ -457,6 +457,9 @@ class CreateAgentWorkspaceDeploymentInput(BaseModel):
     library_version: Optional[str] = Field(
         None, description="Version of the ADK library used to create this deployment"
     )
+    region: Optional[str] = Field(
+        None, description="The region to deploy the agent in"
+    )
     description: Optional[str] = Field(
         None,
         description="Description of the agent deployment (max 1000 characters)",
@@ -542,6 +545,9 @@ class CreateAgentWorkspaceInput(BaseModel):
     project_id: str = Field(..., description="The project id")
     library_version: Optional[str] = Field(
         None, description="Version of the ADK library used to create this workspace"
+    )
+    region: Optional[str] = Field(
+        None, description="The region to deploy the agent in"
     )
     description: Optional[str] = Field(
         None,


### PR DESCRIPTION
## Summary

- Add optional `region` field to agent config YAML (`.gradient/agent.yml`)
- Pass region through to `CreateAgentWorkspaceInput` and `CreateAgentWorkspaceDeploymentInput` API calls
- Add `region` field to API models, config manager, deploy service, and CLI

## Usage

Users can set region in their config:

```yaml
agent_name: my-agent
agent_environment: main
entrypoint_file: main.py
region: atl1
```

If omitted, the backend uses its default region.

## Test plan

- [ ] Deploy with no region set in config (should use default, no behavior change)
- [ ] Deploy with `region: atl1` in config (should pass region to API)
- [ ] Verify `gradient agent configure` still works without region
- [ ] Verify existing agent configs without region field still work


Made with [Cursor](https://cursor.com)