### PR TITLE
Fix region enum mapping for ADK deployments

### DIFF
--- a/gradient_adk/cli/agent/deployment/deploy_service.py
+++ b/gradient_adk/cli/agent/deployment/deploy_service.py
@@ -36,9 +36,9 @@ def _get_adk_version() -> str:
 
 def _region_to_proto_enum(region: str | None) -> str | None:
     """Convert a short region string to the proto enum name expected by the API."""
-    if region is None:
+    if not region or not region.strip():
         return None
-    return f"AGENT_WORKSPACE_DEPLOYMENT_REGION_{region.upper()}"
+    return f"AGENT_WORKSPACE_DEPLOYMENT_REGION_{region.strip().upper()}"
 
 
 class DeployService(Protocol):
@@ -329,6 +329,7 @@ class AgentDeployService:
         code_artifact: AgentDeploymentCodeArtifact,
         project_id: str,
         description: str | None = None,
+        region: str | None = None,
     ) -> str:
         """Create or update the deployment based on what exists.
 

--- a/gradient_adk/cli/agent/deployment/deploy_service.py
+++ b/gradient_adk/cli/agent/deployment/deploy_service.py
@@ -34,6 +34,13 @@ def _get_adk_version() -> str:
         return "unknown"
 
 
+def _region_to_proto_enum(region: str | None) -> str | None:
+    """Convert a short region string to the proto enum name expected by the API."""
+    if region is None:
+        return None
+    return f"AGENT_WORKSPACE_DEPLOYMENT_REGION_{region.upper()}"
+
+
 class DeployService(Protocol):
     """Protocol for agent deployment operations."""
 
@@ -322,7 +329,6 @@ class AgentDeployService:
         code_artifact: AgentDeploymentCodeArtifact,
         project_id: str,
         description: str | None = None,
-        region: str | None = None,
     ) -> str:
         """Create or update the deployment based on what exists.
 
@@ -348,7 +354,7 @@ class AgentDeployService:
                 project_id=project_id,
                 library_version=_get_adk_version(),
                 description=description,
-                region=region,
+                region=_region_to_proto_enum(region),
             )
             workspace_output = await self.client.create_agent_workspace(workspace_input)
 
@@ -376,7 +382,7 @@ class AgentDeployService:
                 agent_deployment_code_artifact=code_artifact,
                 library_version=_get_adk_version(),
                 description=description,
-                region=region,
+                region=_region_to_proto_enum(region),
             )
             deployment_output = await self.client.create_agent_workspace_deployment(
                 deployment_input


### PR DESCRIPTION
## Summary

Fix the region value sent to the API. The proto expects the full enum name (e.g. `AGENT_WORKSPACE_DEPLOYMENT_REGION_ATL1`) not the short string (`atl1`). Without this fix, the region is ignored and defaults to the base region.

Follow-up to #42.

## Test plan

- [ ] Deploy with `region: atl1` in config, verify API response shows ATL1 region
- [ ] Deploy with no region, verify default behavior unchanged


Made with [Cursor](https://cursor.com)