### PR TITLE
AAPP-1104: Make AgentLoggingConfig fields Optional + CLI null-check

### DIFF
--- a/gradient_adk/cli/agent/traces_service.py
+++ b/gradient_adk/cli/agent/traces_service.py
@@ -232,6 +232,24 @@ class GalileoTracesService:
         deployment = deployment_output.agent_workspace_deployment
         logging_config = deployment.logging_config
 
+        # AAPP-1104: a deployment created during a Galileo outage may carry
+        # logging_config = None (or partially-populated fields). The Traces
+        # console URL needs both project_id and log_stream_id to be present,
+        # so surface a clean message to the operator instead of crashing on
+        # attribute access.
+        if (
+            logging_config is None
+            or not logging_config.galileo_project_id
+            or not logging_config.log_stream_id
+        ):
+            raise ValueError(
+                f"Tracing is not provisioned for agent deployment "
+                f"'{agent_deployment_name}' in workspace '{agent_workspace_name}'. "
+                "This usually means the deployment was created while the tracing "
+                "service was unavailable. Retry once Galileo is healthy, or "
+                "redeploy the agent."
+            )
+
         # Get tracing token using workspace UUID
         tracing_token: TracingServiceJWTOutput = await self.client.get_tracing_token(
             agent_workspace_uuid=workspace_uuid,

--- a/gradient_adk/digital_ocean_api/models.py
+++ b/gradient_adk/digital_ocean_api/models.py
@@ -256,14 +256,28 @@ class AgentDeploymentRelease(BaseModel):
 class AgentLoggingConfig(BaseModel):
     """
     Represents Agent Logging Config Details.
+
+    AAPP-1104: every Galileo-derived field is now Optional. The backend may
+    return an AgentLoggingConfig with these fields unset when an agent or
+    deployment was created during a Galileo outage and provisioning was
+    deferred. Callers must handle the None case explicitly (see TracesService
+    for the canonical pattern) and not assume the fields are populated.
     """
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
-    galileo_project_id: str = Field(..., description="Galileo project identifier")
-    galileo_project_name: str = Field(..., description="Name of the Galileo project")
-    log_stream_id: str = Field(..., description="Identifier for the log stream")
-    log_stream_name: str = Field(..., description="Name of the log stream")
+    galileo_project_id: Optional[str] = Field(
+        None, description="Galileo project identifier"
+    )
+    galileo_project_name: Optional[str] = Field(
+        None, description="Name of the Galileo project"
+    )
+    log_stream_id: Optional[str] = Field(
+        None, description="Identifier for the log stream"
+    )
+    log_stream_name: Optional[str] = Field(
+        None, description="Name of the log stream"
+    )
     insights_enabled_at: Optional[datetime] = Field(
         None, description="Timestamp when insights were enabled (RFC3339 timestamp)"
     )


### PR DESCRIPTION
## Summary

Companion to the cthulhu AAPP-1104 PR (https://github.internal.digitalocean.com/digitalocean/cthulhu/pull/161628). After that change, the GenAI API can return an `AgentWorkspaceDeployment` whose `logging_config` is `null` (or whose individual Galileo identifier fields are unset) when the deployment was created during a Galileo outage and provisioning was deferred. The proto field was already optional, but the gradient-adk SDK marked the inner fields as required (`Field(...)`), which would `AttributeError` at runtime as soon as a CLI user ran `gradient agent traces` against such a deployment.

This change makes the SDK and the CLI safe under the new nullable state.

## What's in the box

- **`gradient_adk/digital_ocean_api/models.py`** — `AgentLoggingConfig.galileo_project_id`, `galileo_project_name`, `log_stream_id`, `log_stream_name` are now `Optional[str]` with default `None`. `insights_enabled_at` / `insights_enabled` were already optional. The container `AgentWorkspaceDeployment.logging_config` was already `Optional[AgentLoggingConfig]`, so this lines up with the parent's existing nullability. Existing populated payloads continue to deserialize unchanged.
- **`gradient_adk/cli/agent/traces_service.py`** — `GalileoTracesService.open_traces_console` now checks `logging_config is None`, missing `galileo_project_id`, or missing `log_stream_id` *before* dereferencing, and raises a user-friendly `ValueError`:
  > Tracing is not provisioned for agent deployment '…' in workspace '…'. This usually means the deployment was created while the tracing service was unavailable. Retry once Galileo is healthy, or redeploy the agent.

  No silent failure, no Python traceback.

## Why

INCI-2891 — on 2026-04-01, Galileo API keys expired and every `CreateAgent` returned 500 for ~6.5 h. The cthulhu PR makes Galileo provisioning best-effort so creates succeed during such outages. That's a backend-only fix; the SDK still asserts the fields are populated, so the next `gradient agent traces` invocation after such a create would crash with `AttributeError: 'NoneType' object has no attribute 'galileo_project_id'`. This PR closes that gap.

## Test plan

- [x] `tests/` (excluding pre-broken `test_a2a` and `runtime/test_crewai` which need optional deps): green
- [x] `models.py` coverage at 100% in unit tests after the change
- [x] Manual sanity: `AgentLoggingConfig()` constructs without arguments; `AgentLoggingConfig(galileo_project_id='p', log_stream_id='s')` constructs with partial fields; both round-trip through `model_dump()` cleanly
- [x] Compile-check (`python -m compileall`) — clean
- [ ] Manual end-to-end with the cthulhu PR deployed to preview (will be done by reviewer / before the cthulhu PR merges to prod)

## Out of scope

- The cthulhu backend changes themselves — see https://github.internal.digitalocean.com/digitalocean/cthulhu/pull/161628.
- The auto-reconciler that re-attempts Galileo provisioning for agents created during an outage — intentionally not built because Galileo is being sunset in ~1–2 months.
- UI click-out behavior for missing logging_config — already handled by `useGalileoRedirect.tsx` silently disabling the button.

Ref: AAPP-1104, INCI-2891